### PR TITLE
Fixes an issue where is was impossible to save announcements created in v4

### DIFF
--- a/Components/Business/AnnouncementsController.cs
+++ b/Components/Business/AnnouncementsController.cs
@@ -100,7 +100,7 @@ namespace DotNetNuke.Modules.Announcements.Components.Business
                     ContentTypeId = 4
                 };
 
-                if (objContentItem.ContentItemId == Null.NullInteger)
+                if (objContentItem.ContentItemId == Null.NullInteger || objContentItem.ContentItemId == 0)
                 {
                     announcement.ContentItemID = new ContentController().AddContentItem(objContentItem);
                 }


### PR DESCRIPTION
Closes #30

### Description of PR...
Null check was done on wrong value for missing ContentItemIds

## Changes made
To minimize risk, I kept a null check or Null.NullInterger and on the value 0 just in case.


## PR Template Checklist

- [x] Fixes Bug
- [ ] Feature solution
- [ ] Other