### PR TITLE
Ensure ModuleInfo for correct tab is used if module is shared

### DIFF
--- a/Components/Settings/Settings.cs
+++ b/Components/Settings/Settings.cs
@@ -81,9 +81,15 @@ namespace DotNetNuke.Modules.Announcements.Components.Settings
             _moduleId = moduleId;
             _tabModuleId = tabModuleId;
 
-            var moduleInfo = new ModuleController().GetModule(_moduleId);
-            ModuleSettings = moduleInfo.ModuleSettings;
-            TabModuleSettings = moduleInfo.TabModuleSettings;
+            foreach (ModuleInfo modInfo in (new ModuleController()).GetTabModulesByModule(_moduleId))
+            {
+                if (modInfo.TabModuleID == _tabModuleId)
+                {
+                    ModuleSettings = modInfo.ModuleSettings;
+                    TabModuleSettings = modInfo.TabModuleSettings;
+                    break;
+                }
+            }
 
             History = TabModuleSettings.GetInteger(SettingName.History, _History);
             DescriptionLength = TabModuleSettings.GetInteger(SettingName.DescriptionLength, _DescriptionLength);


### PR DESCRIPTION
### Issue #51 Ensure ModuleInfo for correct tab is used if module is shared

## Changes made
- Use both ModuleID and TabModuleID when reading module settings - previously just use ModuleID
- Affects AnnouncementsSettings and AnnouncementsView

Close #51