### PR TITLE
Fixes an issue where a single announcement was indexed

### DIFF
--- a/Components/Business/AnnouncementsController.cs
+++ b/Components/Business/AnnouncementsController.cs
@@ -277,7 +277,7 @@ namespace DotNetNuke.Modules.Announcements.Components.Business
                 document.PortalId = moduleInfo.PortalID;
                 document.TabId = moduleInfo.TabID;
                 document.Title = announcement.Title;
-                document.UniqueKey = moduleInfo.ModuleID.ToString();
+                document.UniqueKey = "Dnn_Announcements_" + announcement.ItemID.ToString(CultureInfo.InvariantCulture);
                 searchDocuments.Add(document);
             }
             return searchDocuments;


### PR DESCRIPTION
The module id was sent as the UniqueKey for the serach document so it was replacing each search document in the loop of announcements.

Replaced it with a key and the announcement id.

Closes #54

