### PR TITLE
Fixes an issue with search indexing and timezones

### DIFF
--- a/AnnouncementsEdit.ascx.cs
+++ b/AnnouncementsEdit.ascx.cs
@@ -30,6 +30,8 @@ using System.Globalization;
 
 using DotNetNuke.Common;
 using DotNetNuke.Common.Utilities;
+using DotNetNuke.Entities.Portals;
+using DotNetNuke.Entities.Users;
 using DotNetNuke.Framework;
 using DotNetNuke.Framework.JavaScriptLibraries;
 using DotNetNuke.Modules.Announcements.Components.Business;
@@ -38,6 +40,7 @@ using DotNetNuke.Modules.Announcements.MVP.Models;
 using DotNetNuke.Modules.Announcements.MVP.Presenters;
 using DotNetNuke.Modules.Announcements.MVP.Views;
 using DotNetNuke.Services.Exceptions;
+using DotNetNuke.Services.Localization;
 using DotNetNuke.Web.Client;
 using DotNetNuke.Web.Client.ClientResourceManagement;
 using DotNetNuke.Web.Mvp;
@@ -68,7 +71,6 @@ namespace DotNetNuke.Modules.Announcements
         override protected void OnInit(EventArgs e)
         {
             base.OnInit(e);
-            
             JavaScript.RequestRegistration(CommonJs.DnnPlugins);
 
             ClientResourceManager.RegisterStyleSheet(Page, Globals.ApplicationPath + "/DesktopModules/Announcements/AnnouncementsEdit.css", FileOrder.Css.ModuleCss);
@@ -142,7 +144,7 @@ namespace DotNetNuke.Modules.Announcements
                                 ModuleID = ModuleContext.ModuleId,
                                 PortalID = ModuleContext.PortalId,
                                 CreatedByUserID = ModuleContext.PortalSettings.UserId,
-                                CreatedOnDate = DateTime.Now
+                                CreatedOnDate = DateTime.UtcNow
                             };
                     }
                     else
@@ -155,11 +157,11 @@ namespace DotNetNuke.Modules.Announcements
                     announcement.ImageSource = urlImage.FilePath;
                     announcement.Description = teDescription.Text;
                     announcement.URL = ctlURL.Url;
-                    announcement.PublishDate = GetDateTimeValue(publishDate, publishTime, DateTime.Now);
+                    announcement.PublishDate = GetDateTimeValue(publishDate, publishTime, DateTime.UtcNow);
                     announcement.ExpireDate = GetDateTimeValue(expireDate, expireTime);
                     announcement.LastModifiedByUserID = ModuleContext.PortalSettings.UserId;
-                    announcement.LastModifiedOnDate = DateTime.Now;
-                    if (txtViewOrder.Text != "")
+                    announcement.LastModifiedOnDate = DateTime.UtcNow;
+                    if (string.IsNullOrWhiteSpace(txtViewOrder.Text))
                     {
                         announcement.ViewOrder = Convert.ToInt32(txtViewOrder.Text);
                     }
@@ -198,20 +200,29 @@ namespace DotNetNuke.Modules.Announcements
                     if ((!Null.IsNull(Model.AnnouncementInfo.PublishDate)) &&
                         (Model.AnnouncementInfo.PublishDate != (DateTime)SqlDateTime.Null))
                     {
-                        publishDate.SelectedDate = Model.AnnouncementInfo.PublishDate;
-                        publishTime.SelectedDate = Model.AnnouncementInfo.PublishDate;
+                        var portalDatetime = TimeZoneInfo.ConvertTimeFromUtc(Model.AnnouncementInfo.PublishDate.Value, ModuleContext.PortalSettings.TimeZone);
+                        publishDate.SelectedDate = portalDatetime;
+                        publishTime.SelectedDate = portalDatetime;
                     }
                     if ((!Null.IsNull(Model.AnnouncementInfo.ExpireDate)) &&
                         (Model.AnnouncementInfo.ExpireDate != (DateTime)SqlDateTime.Null))
                     {
-                        expireDate.SelectedDate = Model.AnnouncementInfo.ExpireDate;
-                        expireTime.SelectedDate = Model.AnnouncementInfo.ExpireDate;
+                        var portalDateTime = TimeZoneInfo.ConvertTimeFromUtc(Model.AnnouncementInfo.ExpireDate.Value, ModuleContext.PortalSettings.TimeZone);
+                        expireDate.SelectedDate = portalDateTime;
+                        expireTime.SelectedDate = portalDateTime;
                     }
 
-                    ctlAudit.CreatedDate = Model.AnnouncementInfo.CreatedOnDate.ToString(CultureInfo.InvariantCulture);
+                    var user = UserController.Instance.GetCurrentUserInfo();
+                    var userPreferredCulture = CultureInfo.InvariantCulture;
+                    if (user != null && !string.IsNullOrWhiteSpace(user.Profile.PreferredLocale))
+                    {
+                        userPreferredCulture = new CultureInfo(user.Profile.PreferredLocale);
+                    }
+                    
+                    ctlAudit.CreatedDate = TimeZoneInfo.ConvertTimeFromUtc(Model.AnnouncementInfo.CreatedOnDate, ModuleContext.PortalSettings.TimeZone).ToString(userPreferredCulture);
                     ctlAudit.CreatedByUser = Model.AnnouncementInfo.CreatedByUserID.ToString(CultureInfo.InvariantCulture);
                     ctlAudit.LastModifiedByUser = Model.AnnouncementInfo.LastModifiedByUserID.ToString(CultureInfo.InvariantCulture);
-                    ctlAudit.LastModifiedDate = Model.AnnouncementInfo.LastModifiedOnDate.ToString(CultureInfo.InvariantCulture);
+                    ctlAudit.LastModifiedDate = TimeZoneInfo.ConvertTimeFromUtc(Model.AnnouncementInfo.LastModifiedOnDate, ModuleContext.PortalSettings.TimeZone).ToString(userPreferredCulture);
                     ctlTracking.URL = Model.AnnouncementInfo.URL;
                     ctlTracking.ModuleID = ModuleContext.ModuleId;
                 }
@@ -274,11 +285,18 @@ namespace DotNetNuke.Modules.Announcements
             {
                 resultValue = dnnDatePicker.SelectedDate;
             }
+
             if ((dnnTimePicker.SelectedTime != null) && (resultValue.HasValue))
             {
                 resultValue = resultValue.Value.Add((TimeSpan)dnnTimePicker.SelectedTime);
             }
-            return resultValue;
+
+            if (resultValue.HasValue)
+            {
+                return TimeZoneInfo.ConvertTimeToUtc(resultValue.Value, ModuleContext.PortalSettings.TimeZone);
+            }
+
+            return null;
         }
 
         private DateTime? GetDateTimeValue(DnnDatePicker dnnDatePicker, DnnTimePicker dnnTimePicker, DateTime defaultValue)

--- a/AnnouncementsEdit.ascx.cs
+++ b/AnnouncementsEdit.ascx.cs
@@ -199,7 +199,7 @@ namespace DotNetNuke.Modules.Announcements
                     if ((!Null.IsNull(Model.AnnouncementInfo.PublishDate)) &&
                         (Model.AnnouncementInfo.PublishDate != (DateTime)SqlDateTime.Null))
                     {
-                        var portalDatetime = TimeZoneInfo.ConvertTimeFromUtc(Model.AnnouncementInfo.PublishDate.Value, ModuleContext.PortalSettings.TimeZone);
+                        var portalDateTime = TimeZoneInfo.ConvertTimeFromUtc(Model.AnnouncementInfo.PublishDate.Value, ModuleContext.PortalSettings.TimeZone);
                         publishDate.SelectedDate = portalDatetime;
                         publishTime.SelectedDate = portalDatetime;
                     }

--- a/AnnouncementsEdit.ascx.cs
+++ b/AnnouncementsEdit.ascx.cs
@@ -201,7 +201,7 @@ namespace DotNetNuke.Modules.Announcements
                     {
                         var portalDateTime = TimeZoneInfo.ConvertTimeFromUtc(Model.AnnouncementInfo.PublishDate.Value, ModuleContext.PortalSettings.TimeZone);
                         publishDate.SelectedDate = portalDatetime;
-                        publishTime.SelectedDate = portalDatetime;
+                        publishTime.SelectedDate = portalDateTime;
                     }
                     if ((!Null.IsNull(Model.AnnouncementInfo.ExpireDate)) &&
                         (Model.AnnouncementInfo.ExpireDate != (DateTime)SqlDateTime.Null))

--- a/AnnouncementsEdit.ascx.cs
+++ b/AnnouncementsEdit.ascx.cs
@@ -200,7 +200,7 @@ namespace DotNetNuke.Modules.Announcements
                         (Model.AnnouncementInfo.PublishDate != (DateTime)SqlDateTime.Null))
                     {
                         var portalDateTime = TimeZoneInfo.ConvertTimeFromUtc(Model.AnnouncementInfo.PublishDate.Value, ModuleContext.PortalSettings.TimeZone);
-                        publishDate.SelectedDate = portalDatetime;
+                        publishDate.SelectedDate = portalDateTime;
                         publishTime.SelectedDate = portalDateTime;
                     }
                     if ((!Null.IsNull(Model.AnnouncementInfo.ExpireDate)) &&

--- a/AnnouncementsEdit.ascx.cs
+++ b/AnnouncementsEdit.ascx.cs
@@ -161,7 +161,7 @@ namespace DotNetNuke.Modules.Announcements
                     announcement.ExpireDate = GetDateTimeValue(expireDate, expireTime);
                     announcement.LastModifiedByUserID = ModuleContext.PortalSettings.UserId;
                     announcement.LastModifiedOnDate = DateTime.UtcNow;
-                    if (string.IsNullOrWhiteSpace(txtViewOrder.Text))
+                    if (!string.IsNullOrWhiteSpace(txtViewOrder.Text))
                     {
                         announcement.ViewOrder = Convert.ToInt32(txtViewOrder.Text);
                     }
@@ -174,7 +174,6 @@ namespace DotNetNuke.Modules.Announcements
 
                     // redirect back to page
                     Response.Redirect(ReturnURL, true);
-
                 }
             }
             catch (Exception exc)

--- a/AssemblyInfo.cs
+++ b/AssemblyInfo.cs
@@ -8,6 +8,6 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-[assembly: System.Reflection.AssemblyVersion("07.02.03.00")]
+[assembly: System.Reflection.AssemblyVersion("07.02.04.00")]
 
 

--- a/Components/Business/AnnouncementInfo.cs
+++ b/Components/Business/AnnouncementInfo.cs
@@ -89,9 +89,17 @@ namespace DotNetNuke.Modules.Announcements.Components.Business
         public int ModuleID { get; set; }
         public string Title { get; set; }
         public string URL { get; set; }
+
+        /// <summary>
+        /// Gets or sets the UTC expiration date and time.
+        /// </summary>
         public DateTime? ExpireDate { get; set; }
         public string Description { get; set; }
         public int ViewOrder { get; set; }
+
+        /// <summary>
+        /// Gets or sets the UTC publish date and time.
+        /// </summary>
         public DateTime? PublishDate { get; set; }
         public string ImageSource { get; set; }
         public int PortalID { get; set; }
@@ -100,10 +108,18 @@ namespace DotNetNuke.Modules.Announcements.Components.Business
         public bool IsEditable { get; set; }
         [Browsable(false), XmlIgnore]
         public int CreatedByUserID { get; set; }
+
+        /// <summary>
+        /// Gets or sets the UTC creation date.
+        /// </summary>
         [Browsable(false), XmlIgnore]
         public DateTime CreatedOnDate { get; set; }
         [Browsable(false), XmlIgnore]
         public int LastModifiedByUserID { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the UTC last modification date.
+        /// </summary>
         [Browsable(false), XmlIgnore]
         public DateTime LastModifiedOnDate { get; set; }
 
@@ -355,6 +371,7 @@ namespace DotNetNuke.Modules.Announcements.Components.Business
         public string GetProperty(string strPropertyName, string strFormat, CultureInfo formatProvider, UserInfo AccessingUser, Scope AccessLevel, ref bool PropertyNotFound)
         {
             PortalSettings portalSettings = PortalController.Instance.GetCurrentPortalSettings();
+            var userInfo = UserController.Instance.GetCurrentUserInfo();
             string outputFormat = strFormat == string.Empty ? "D" : strFormat;
             switch (strPropertyName.ToLowerInvariant())
             {
@@ -445,13 +462,13 @@ namespace DotNetNuke.Modules.Announcements.Components.Business
                     return NewWindow ? "_blank" : "_self";
                 case "createddate":
                 case "createdondate":
-                    return (CreatedOnDate.ToString(outputFormat, formatProvider));
+                    return FormatDisplayDateTime(CreatedOnDate, userInfo, portalSettings, outputFormat, formatProvider);
                 case "lastmodifiedondate":
-                    return (LastModifiedOnDate.ToString(outputFormat, formatProvider));
+                    return FormatDisplayDateTime(LastModifiedOnDate, userInfo, portalSettings, outputFormat, formatProvider);
                 case "publishdate":
-                    return PublishDate.HasValue ? (PublishDate.Value.ToString(outputFormat, formatProvider)) : "";
+                    return PublishDate.HasValue ? FormatDisplayDateTime(PublishDate.Value, userInfo, portalSettings, outputFormat, formatProvider) : "";
                 case "expiredate":
-                    return ExpireDate.HasValue ? (ExpireDate.Value.ToString(outputFormat, formatProvider)) : "";
+                    return ExpireDate.HasValue ? FormatDisplayDateTime(ExpireDate.Value, userInfo, portalSettings, outputFormat, formatProvider) : "";
                 case "more":
                     return Localization.GetString("More.Text", _localResourceFile);
                 case "readmore":
@@ -484,6 +501,21 @@ namespace DotNetNuke.Modules.Announcements.Components.Business
         }
 
         #endregion
+
+        private static string FormatDisplayDateTime(DateTime dateTime, UserInfo userInfo, PortalSettings portalSettings, string outputFormat, CultureInfo formatProvider)
+        {
+            if (userInfo != null)
+            {
+                return userInfo.LocalTime(dateTime).ToString(outputFormat, formatProvider);
+            }
+
+            if (portalSettings.TimeZone != null)
+            {
+                return TimeZoneInfo.ConvertTimeFromUtc(dateTime, portalSettings.TimeZone).ToString(outputFormat, formatProvider);
+            }
+
+            return (dateTime.ToString(outputFormat, formatProvider));
+        }
     }
 }
 

--- a/Components/Business/AnnouncementsController.cs
+++ b/Components/Business/AnnouncementsController.cs
@@ -292,7 +292,7 @@ namespace DotNetNuke.Modules.Announcements.Components.Business
                 document.AuthorUserId = announcement.CreatedByUserID;
                 document.Body = announcement.Description;
                 document.CultureCode = moduleInfo.CultureCode;
-                document.Description = HtmlUtils.Shorten(announcement.Description, descriptionLenght, "...");
+                document.Description = HtmlUtils.Shorten(announcement.Description, descriptionLength, "...");
                 document.IsActive = CheckIfAnnouncementIsActive(announcement);
                 document.ModifiedTimeUtc = announcement.LastModifiedOnDate.ToUniversalTime();
                 document.ModuleDefId = moduleInfo.ModuleDefID;

--- a/Components/Business/AnnouncementsController.cs
+++ b/Components/Business/AnnouncementsController.cs
@@ -281,7 +281,7 @@ namespace DotNetNuke.Modules.Announcements.Components.Business
             if (!string.IsNullOrWhiteSpace(moduleSettings["descriptionLength"].ToString()))
             {
                 int.TryParse(moduleSettings["descriptionLength"].ToString(), out descriptionLength);
-                if (descriptionLenght < 1) { descriptionLenght = 1950; }                    
+                if (descriptionLength < 1) { descriptionLength = 1950; }                    
                     //max length of description is 2000 char, take a bit less to make sure it fits...                
             }
             var searchDocuments = new List<SearchDocument>();

--- a/Components/Business/AnnouncementsController.cs
+++ b/Components/Business/AnnouncementsController.cs
@@ -1,7 +1,7 @@
 #region License
 
 //
-// DotNetNuke® - http://www.dotnetnuke.com
+// DotNetNukeÂ® - http://www.dotnetnuke.com
 // Copyright (c) 2002-2012
 // by DotNetNuke Corporation
 //
@@ -277,7 +277,7 @@ namespace DotNetNuke.Modules.Announcements.Components.Business
         public override IList<SearchDocument> GetModifiedSearchDocuments(ModuleInfo moduleInfo, DateTime beginDateUtc)
         {
             var moduleSettings = moduleInfo.ModuleSettings;
-            int descriptionLenght = 100;
+            int descriptionLength = 100;
             if (!string.IsNullOrWhiteSpace(moduleSettings["descriptionLength"].ToString()))
             {
                 int.TryParse(moduleSettings["descriptionLength"].ToString(), out descriptionLenght);
@@ -533,4 +533,3 @@ namespace DotNetNuke.Modules.Announcements.Components.Business
     }
 
 }
-

--- a/Components/Business/AnnouncementsController.cs
+++ b/Components/Business/AnnouncementsController.cs
@@ -280,7 +280,7 @@ namespace DotNetNuke.Modules.Announcements.Components.Business
             int descriptionLength = 100;
             if (!string.IsNullOrWhiteSpace(moduleSettings["descriptionLength"].ToString()))
             {
-                int.TryParse(moduleSettings["descriptionLength"].ToString(), out descriptionLenght);
+                int.TryParse(moduleSettings["descriptionLength"].ToString(), out descriptionLength);
                 if (descriptionLenght < 1) { descriptionLenght = 1950; }                    
                     //max length of description is 2000 char, take a bit less to make sure it fits...                
             }

--- a/Components/Settings/Settings.cs
+++ b/Components/Settings/Settings.cs
@@ -125,13 +125,7 @@ namespace DotNetNuke.Modules.Announcements.Components.Settings
             objModules.UpdateTabModuleSetting(_tabModuleId, SettingName.TemplateName, TemplateName);
             objModules.UpdateTabModuleSetting(_tabModuleId, SettingName.TemplateLocation, TemplateLocation);
 
-
-            ModuleController.SynchronizeModule(_moduleId);
-            // DataCache.RemoveCache(ModuleController.CacheKey(_moduleId) + "_viewType");
-            // Module caching has been updated in 5.2.0, this method is no longer used
-
             DataCache.RemoveCache(CacheConstants.SettingsCacheKeyFormat(_moduleId, _tabModuleId));
-
         }
 
         public bool TryGetValue(string key, out string value)

--- a/DotNetNuke.Announcements.dnn
+++ b/DotNetNuke.Announcements.dnn
@@ -1,6 +1,6 @@
 ﻿<dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="DNN_Announcements" type="Module" version="07.02.03">
+    <package name="DNN_Announcements" type="Module" version="07.02.04">
       <friendlyName>Announcements</friendlyName>
       <description>This module renders a list of announcements. The way the announcements are rendered is completely customizable by templating.</description>
       <iconFile>~/DesktopModules/Announcements/Images/icon-announcements-32px.png</iconFile>
@@ -180,6 +180,15 @@
             <permission code="DNNANNOUNCEMENTS" key="EDITTEMPLATE" name="Edit Template" />
             <permission code="DNNANNOUNCEMENTS" key="CANSUBSCRIBE" name="Can Subscribe" />
           </permissions>
+          <eventMessage>
+            <processorType>DotNetNuke.Entities.Modules.EventMessageProcessor, DotNetNuke</processorType>
+            <processorCommand>UpgradeModule</processorCommand>
+            <attributes>
+              <businessControllerClass>DotNetNuke.Modules.Announcements.Components.Business.AnnouncementsController</businessControllerClass>
+              <desktopModuleID>[DESKTOPMODULEID]</desktopModuleID>
+              <upgradeVersionsList>07.02.04</upgradeVersionsList>
+            </attributes>
+          </eventMessage>
         </component>
         <component type="Assembly">
           <assemblies>

--- a/MVP/Presenters/AnnouncementsViewPresenter.cs
+++ b/MVP/Presenters/AnnouncementsViewPresenter.cs
@@ -78,7 +78,7 @@ namespace DotNetNuke.Modules.Announcements.MVP.Presenters
             DateTime datStartDate = Null.NullDate;
             if (!View.Model.Settings.History.IsDnnNull())
             {
-                datStartDate = DateTime.Now.AddDays(-View.Model.Settings.History);
+                datStartDate = DateTime.UtcNow.AddDays(-View.Model.Settings.History);
             }
 
             switch (View.Model.Settings.DefaultViewType)
@@ -90,7 +90,7 @@ namespace DotNetNuke.Modules.Announcements.MVP.Presenters
                     View.Model.Announcements = _announcementsController.GetExpiredAnnouncements(ModuleId);
                     break;
                 case ViewTypes.Future:
-                    View.Model.Announcements = _announcementsController.GetAnnouncements(ModuleId, DateTime.Now, Null.NullDate);
+                    View.Model.Announcements = _announcementsController.GetAnnouncements(ModuleId, DateTime.UtcNow, Null.NullDate);
                     break;
                 case ViewTypes.All:
                     View.Model.Announcements = _announcementsController.GetAnnouncements(ModuleId, Null.NullDate, Null.NullDate);


### PR DESCRIPTION
### Description of PR...
Fixes #59 and prevents marking the module last modified date when only changing settings.


## Changes made
- Ensures all DataStore usage of times are in UTC 
- Prevents marking the module last modified date when only changing settings


## PR Template Checklist

- [x] Fixes Bug
- [ ] Feature solution
- [ ] Other